### PR TITLE
Arrange conda channels

### DIFF
--- a/conda-envs/concoct.yml
+++ b/conda-envs/concoct.yml
@@ -3,7 +3,6 @@ channels:
   - conda-forge
   - defaults
   - bioconda
-  - ursky
 dependencies:
   - kallisto=0.46.*
   - concoct=1.1.*

--- a/conda-envs/genome-assembly.yml
+++ b/conda-envs/genome-assembly.yml
@@ -1,7 +1,7 @@
 name: metabiome-genome-assembly
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
   - defaults
 dependencies:
   - spades=3.12.*

--- a/conda-envs/maxbin2.yml
+++ b/conda-envs/maxbin2.yml
@@ -3,7 +3,6 @@ channels:
   - conda-forge
   - bioconda
   - defaults
-  - ursky
 dependencies:
   - maxbin2=2.2.*
   - perl=5.26.*

--- a/conda-envs/metabat2.yml
+++ b/conda-envs/metabat2.yml
@@ -1,8 +1,7 @@
 name: metabiome-metabat2
 channels:
-  - ursky
-  - bioconda
   - conda-forge
+  - bioconda
   - defaults
 dependencies:
   - metabat2=2.15

--- a/conda-envs/picking16S.yml
+++ b/conda-envs/picking16S.yml
@@ -1,7 +1,7 @@
 name: metabiome-picking16S
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
   - defaults
 dependencies:
   - bbmap=38.87

--- a/conda-envs/preprocessing.yml
+++ b/conda-envs/preprocessing.yml
@@ -1,7 +1,7 @@
 name: metabiome-preprocessing
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
   - defaults
 dependencies:
   - trimmomatic=0.39

--- a/conda-envs/taxonomic-binning.yml
+++ b/conda-envs/taxonomic-binning.yml
@@ -1,7 +1,7 @@
 name: metabiome-taxonomic-binning
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
   - defaults
 dependencies:
   - kraken2=2.1


### PR DESCRIPTION
Arrange conda channels according to priority. In most cases, conda-forge should have highest priority. Hence, it is set as the first channel into most of the yml files. Also, I deleted the channel ursky from the CONCOCT, MetaBAT2 and MaxBin2 yml files because it was not necessary.  After these modifications, I created the channels once again and the scripts ran successfully.
 