### PR TITLE
Change readlink's flag

### DIFF
--- a/scripts/bbduk.sh
+++ b/scripts/bbduk.sh
@@ -35,7 +35,7 @@ while (("$#")); do
         -h|--help ) usage; exit 0 ;;
         -i )        input_dir=$(readlink -f "$2"); shift 2 ;;
         -o )        out_dir=$(readlink -m "$2"); shift 2 ;;
-        -D )        database=$(readlink -f "$2"); shift 2 ;;
+        -D )        database=$(readlink -m "$2"); shift 2 ;;
         -t )        threads="$2"; shift 2 ;;
         -opts )     shift;bbduk_opts="$@"; break ;;
         * )         echo "Option '$1' not recognized"; exit 1 ;;

--- a/scripts/bowtie2.sh
+++ b/scripts/bowtie2.sh
@@ -37,10 +37,10 @@ while (("$#")); do
         -h|--help ) usage; exit 0 ;;
         -i )        input_dir=$(readlink -f "$2"); shift 2 ;;
         -o )        out_dir=$(readlink -m "$2"); shift 2 ;;
-        -ho )       host=$(readlink -f "$2"); shift 2 ;;
+        -ho )       host=$(readlink -m "$2"); shift 2 ;;
         -t )        threads="$2"; shift 2 ;;
-        -ph )       PhiX=$(readlink -f "$2"); shift 2 ;;
-        -hu )       Human=$(readlink -f "$2"); shift 2 ;;
+        -ph )       PhiX=$(readlink -m "$2"); shift 2 ;;
+        -hu )       Human=$(readlink -m "$2"); shift 2 ;;
         -opts )     shift; bowtie2_opts="$@"; break ;;
         * )         echo "Option '$1' not recognized"; exit 1 ;;
     esac

--- a/scripts/concoct.sh
+++ b/scripts/concoct.sh
@@ -39,7 +39,7 @@ while (("$#")); do
         -i )        input_dir=$(readlink -f "$2"); shift 2 ;;
         -o )        out_dir=$(readlink -m "$2"); shift 2 ;;
         -ch )       chunk_size="$2"; shift 2 ;;
-        -co )       cov_dir="$(readlink -f "$2")"; shift 2 ;;
+        -co )       cov_dir="$(readlink -m "$2")"; shift 2 ;;
         -t )        threads="$2"; shift 2 ;;
         -opts )     shift; concoct_opts="$@"; break ;;
         * )         echo "Option '$1' not recognized"; exit 1 ;;

--- a/scripts/concoct.sh
+++ b/scripts/concoct.sh
@@ -39,7 +39,7 @@ while (("$#")); do
         -i )        input_dir=$(readlink -f "$2"); shift 2 ;;
         -o )        out_dir=$(readlink -m "$2"); shift 2 ;;
         -ch )       chunk_size="$2"; shift 2 ;;
-        -co )       cov_dir="$(readlink -m "$2")"; shift 2 ;;
+        -co )       cov_dir=$(readlink -m "$2"); shift 2 ;;
         -t )        threads="$2"; shift 2 ;;
         -opts )     shift; concoct_opts="$@"; break ;;
         * )         echo "Option '$1' not recognized"; exit 1 ;;

--- a/scripts/kaiju.sh
+++ b/scripts/kaiju.sh
@@ -41,7 +41,7 @@ while (("$#")); do
         -h|--help ) usage; exit 0 ;;
         -i )        input_dir=$(readlink -f "$2"); shift 2 ;;
         -o )        out_dir=$(readlink -m "$2"); shift 2 ;;
-        -D )        database=$(readlink -f "$2"); shift 2 ;;
+        -D )        database=$(readlink -m "$2"); shift 2 ;;
         -d )        name_kaijudb="$2"; shift 2 ;;
         -t )        threads="$2"; shift 2 ;;
         -c )        class=class; shift 1 ;;

--- a/scripts/maxbin2.sh
+++ b/scripts/maxbin2.sh
@@ -38,7 +38,7 @@ while [[ -n "$1" ]]; do
         -h|--help ) usage; exit 0 ;;
         -i )        input_dir=$(readlink -f "$2"); shift 2 ;;
         -o )        out_dir=$(readlink -m "$2"); shift 2 ;;
-        -a )        abundance_dir=$(readlink -f "$2"); shift 2 ;;
+        -a )        abundance_dir=$(readlink -m "$2"); shift 2 ;;
         -t )        threads="$2"; shift 2 ;;
      -opts )        shift; maxbin2_opts="$@"; break ;;
          * )        echo "Option '$1' not recognized"; exit 1 ;;

--- a/scripts/metabat2.sh
+++ b/scripts/metabat2.sh
@@ -37,7 +37,7 @@ while (("$#")); do
         -h|--help ) usage; exit 0 ;;
         -i )       input_dir=$(readlink -f "$2"); shift 2 ;;
         -o )       out_dir=$(readlink -m "$2"); shift 2 ;;
-        -co )      cov_dir=$(readlink -f "$2"); shift 2 ;;
+        -co )      cov_dir=$(readlink -m "$2"); shift 2 ;;
         -t )       threads="$2"; shift 2 ;;
         -opts )    shift; metabat2_opts="$@"; break ;;
         * )        echo "Option '$1' not recognized"; exit 1 ;;

--- a/scripts/metaphlan3.sh
+++ b/scripts/metaphlan3.sh
@@ -35,7 +35,7 @@ while (("$#")); do
         -h|--help ) usage; exit 0;;
         -i )        input_dir=$(readlink -f "$2"); shift 2;;
         -o )        out_dir=$(readlink -m "$2"); shift 2;;
-        -d )        met_db=$(readlink -f "$2"); shift 2;;
+        -d )        met_db=$(readlink -m "$2"); shift 2;;
         -t )        threads="$2"; shift 2;;
         -opts )     shift; metaphlan_opts="$@"; break ;;
         * )         echo "Option '$1' not recognized"; exit 1;;


### PR DESCRIPTION
-Change readlink's flag from `-f` to `-m` in order to avoid silent errors, in the following scripts:

-metabat2.sh
-maxbin2.sh
-concoct.sh
-metaphlan3.sh
-kaiju.sh
-bbduk.sh
-bowtie2.sh
