### PR TITLE
Update MultiQC to version 1.10

### DIFF
--- a/conda-envs/preprocessing.yml
+++ b/conda-envs/preprocessing.yml
@@ -9,5 +9,5 @@ dependencies:
   - rename=1.601
   - entrez-direct=13.9
   - fastqc=0.11
-  - multiqc=1.6
+  - multiqc=1.10
   - wget=1.20.1


### PR DESCRIPTION
Hi! I have updated the version of MultiQC from 1.6 to 1.10 in the `metabiome-preprocessing` environment. I did some tests and it worked fine. It has also removed the [warning regarding the YAML loader](https://github.com/Nesper94/Metabiome/pull/33#issuecomment-835533924).