### PR TITLE
Add option to show programs native help message

### DIFF
--- a/scripts/bbduk.sh
+++ b/scripts/bbduk.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # BBDuk wrapper script to pick 16S rDNA sequences from metagenomic samples.
 # Written by: Phagomica Group
-# Last updated on: 2020-12-11
+# Last updated on: 2021-05-24
 
 set -e
 
@@ -23,6 +23,7 @@ Options:
   -t NUM            Number of threads to use. (default=1)
   -opts OPTIONS     BBDuk's options.
   -h, --help        Show this help.
+  -hh               Show BBDuk's help message.
 HELP_USAGE
 }
 
@@ -33,11 +34,12 @@ validate_arguments "$#"
 while (("$#")); do
     case "$1" in
         -h|--help ) usage; exit 0 ;;
+        -hh )       activate_env metabiome-picking16S; bbduk.sh -h; exit 0 ;;
         -i )        input_dir=$(readlink -f "$2"); shift 2 ;;
         -o )        out_dir=$(readlink -m "$2"); shift 2 ;;
         -D )        database=$(readlink -m "$2"); shift 2 ;;
         -t )        threads="$2"; shift 2 ;;
-        -opts )     shift;bbduk_opts="$@"; break ;;
+        -opts )     shift; bbduk_opts="$@"; break ;;
         * )         echo "Option '$1' not recognized"; exit 1 ;;
     esac
 done

--- a/scripts/bowtie2.sh
+++ b/scripts/bowtie2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Bowtie2 wrapper script to filter out contaminations from metagenomic samples.
 # Written by: Phagomica Group
-# Last updated on: 2020-13-11
+# Last updated on: 2021-05-24
 
 set -e
 
@@ -25,6 +25,7 @@ Options:
   -t  NUM           Number of threads to use. (default=1)
   -opts OPTIONS     Bowtie2's options.
   -h, --help        Show this help.
+  -hh               Show Bowtie2's help message.
 HELP_USAGE
 }
 
@@ -35,6 +36,7 @@ validate_arguments "$#"
 while (("$#")); do
     case "$1" in
         -h|--help ) usage; exit 0 ;;
+        -hh )       activate_env metabiome-preprocessing; bowtie2 -h; exit 0 ;;
         -i )        input_dir=$(readlink -f "$2"); shift 2 ;;
         -o )        out_dir=$(readlink -m "$2"); shift 2 ;;
         -ho )       host=$(readlink -m "$2"); shift 2 ;;

--- a/scripts/concoct.sh
+++ b/scripts/concoct.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # CONCOCT wrapper script for the binning of contig assemblies.
 # Written by: Phagomica Group
-# Last updated on: 2021-02-14
+# Last updated on: 2021-05-24
 
 set -e
 SCRIPTS_DIR=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
@@ -26,6 +26,7 @@ Options:
   -ch NUM           Contigs's chunk size. (default=1000)
   -opts OPTIONS     CONCOCT's options.
   -h, --help        Show this help.
+  -hh               Show CONCOCT's help message.
 HELP_USAGE
 }
 
@@ -36,6 +37,7 @@ validate_arguments "$#"
 while (("$#")); do
     case "$1" in
         -h|--help ) usage; exit 0 ;;
+        -hh )       activate_env metabiome-concoct; concoct -h; exit 0 ;;
         -i )        input_dir=$(readlink -f "$2"); shift 2 ;;
         -o )        out_dir=$(readlink -m "$2"); shift 2 ;;
         -ch )       chunk_size="$2"; shift 2 ;;

--- a/scripts/coverm.sh
+++ b/scripts/coverm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Wrapper script to generate a read-based coverage table with CoverM.
 # Written by: Phagomica Group
-# Last updated on: 2021-02-14
+# Last updated on: 2021-05-24
 
 set -e
 SCRIPTS_DIR=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
@@ -25,6 +25,7 @@ Options
   -t NUM            Number of threads. (default=1)
   -opts OPTIONS     CoverM's options.
   -h, --help        Show this help.
+  -hh               Show CoverM's help message.
 HELP_USAGE
 }
 
@@ -35,6 +36,7 @@ validate_arguments "$#"
 while (("$#")); do
     case "$1" in
         -h|--help ) usage; exit 0 ;;
+        -hh )      activate_env metabiome-concoct; coverm -h; exit 0 ;;
         -i )       input_dir=$(readlink -f "$2"); shift 2 ;;
         -o )       out_dir=$(readlink -m "$2"); shift 2 ;;
         -t )       threads="$2"; shift 2 ;;

--- a/scripts/humann3.sh
+++ b/scripts/humann3.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # HUMAnN 3.0 wrapper script
 # Written by: Estefany Lorenzana, Cristian Grisales and Juan Camilo Arboleda
-# Last updated on: 2021-02-15
+# Last updated on: 2021-05-24
 
 set -e
 
@@ -20,6 +20,7 @@ Required:
 Options:
   -t  NUM     Number of threads to use
   -h, --help  Show this help
+  -hh         Show HUMAnN3's help message.
 
 Note: Before running this script you should have downloaded the nucleotide and
 protein databases with humann_databases. Activate environment with
@@ -35,6 +36,7 @@ validate_arguments "$#"
 while [[ -n "$1" ]]; do
     case "$1" in
         -h|--help ) usage; exit 0 ;;
+        -hh )       activate_env metabiome-taxonomic-profiling; humann -h; exit 0 ;;
         -i )        input_dir=$(readlink -f "$2"); shift ;;
         -o )        out_dir=$(readlink -m "$2"); shift ;;
         -t )        threads="$2"; shift ;;
@@ -63,7 +65,8 @@ mkdir "$out_dir"/tmp
 
 # Cat paired-end reads and save to tmp/.
 # HUMAnN doesn't use paired-end information, however it is useful to convert the
-# paired reads to a single input file: https://forum.biobakery.org/t/paired-end-files-humann2/396/4
+# paired reads to a single input file:
+# https://forum.biobakery.org/t/paired-end-files-humann2/396/4
 for file in "$input_dir"/*; do
 
     # Make sure to process only fastq, fq.gz or fastq.gz files

--- a/scripts/kaiju.sh
+++ b/scripts/kaiju.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Kaiju wrapper script for the taxonomic binning of metagenomic samples.
 # Written by: Phagomica Group
-# Last updated on: 2021-04-7
+# Last updated on: 2021-05-24
 
 set -e
 
@@ -29,6 +29,7 @@ Options:
   -k                Generate krona graphs of Kaiju's output files.
   -opts OPTIONS     Kaiju's options.
   -h, --help        Show this help.
+  -hh               Show Kaiju's help message.
 HELP_USAGE
 }
 
@@ -39,6 +40,7 @@ validate_arguments "$#"
 while (("$#")); do
     case "$1" in
         -h|--help ) usage; exit 0 ;;
+        -hh )       activate_env metabiome-taxonomic-binning; kaiju -h; exit 0 ;;
         -i )        input_dir=$(readlink -f "$2"); shift 2 ;;
         -o )        out_dir=$(readlink -m "$2"); shift 2 ;;
         -D )        database=$(readlink -m "$2"); shift 2 ;;

--- a/scripts/kraken2.sh
+++ b/scripts/kraken2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Kraken2 wrapper script for the taxonomic binning of reads.
 # Written by: Phagomica group
-# Last updated on: 2021-02-08
+# Last updated on: 2021-05-24
 
 set -e
 
@@ -21,6 +21,7 @@ Options:
   -db database    Path to database used to assign the taxonomic labels to sequences (default: standard-kraken2-db)"
   -t  NUM         Number of threads to use (default: 1)"
   -h, --help      Show this help"
+  -hh             Show Kraken2's help message.
 HELP_USAGE
 }
 
@@ -31,6 +32,7 @@ validate_arguments "$#"
 while [[ -n "$1" ]]; do
     case "$1" in
         -h|--help ) usage; exit 0 ;;
+        -hh )       activate_env metabiome-taxonomic-binning; kraken2 -h; exit 0 ;;
         -i )        input_dir=$(readlink -f "$2"); shift ;;
         -o )        out_dir=$(readlink -m "$2"); shift ;;
         -db )       DBNAME="$2"; shift ;;

--- a/scripts/maxbin2.sh
+++ b/scripts/maxbin2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # MaxBin2 wrapper script for binning contigs.
 # Written by: Phagomica Group
-# Last updated on:  2021-03-24
+# Last updated on: 2021-05-24
 
 set -e
 SCRIPTS_DIR=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
@@ -26,6 +26,7 @@ Options:
   -t NUM            Number of threads. (default=1)
   -opts OPTIONS     MaxBin2's options.
   -h, --help        Show this help.
+  -hh               Show MaxBin2's help message.
 HELP_USAGE
 }
 
@@ -36,6 +37,7 @@ validate_arguments "$#"
 while [[ -n "$1" ]]; do
     case "$1" in
         -h|--help ) usage; exit 0 ;;
+        -hh )       activate_env metabiome-maxbin2; run_MaxBin.pl; exit 0 ;;
         -i )        input_dir=$(readlink -f "$2"); shift 2 ;;
         -o )        out_dir=$(readlink -m "$2"); shift 2 ;;
         -a )        abundance_dir=$(readlink -m "$2"); shift 2 ;;

--- a/scripts/megahit.sh
+++ b/scripts/megahit.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Metagenomic assembly using MEGAHIT-1.2.9
 # Written by: Phagomica_club
+# Last updated on: 2021-05-24
 
 set -e
 
@@ -20,6 +21,7 @@ Options:
   -t NUM          Number of threads to use (default: 4).
   -opts OPTIONS   Megahit's options.
   -h, --help      Show this help.
+  -hh             Show MEGAHIT's help message.
 HELP_USAGE
 }
 
@@ -29,6 +31,7 @@ validate_arguments "$#"
 while [[ -n "$1" ]]; do
     case "$1" in
         -h|--help ) usage; exit 0 ;;
+        -hh )       activate_env metabiome-genome-assembly; megahit -h; exit 0 ;;
         -i )        input_dir=$(readlink -f "$2"); shift ;;
         -o )        out_dir=$(readlink -m "$2"); shift ;;
         -t )        threads="$2"; shift ;;

--- a/scripts/metabat2.sh
+++ b/scripts/metabat2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # MetaBAT2 wrapper script for the binning of contig assemblies.
 # Written by: Phagomica Group
-# Last updated on: 2021-03-24
+# Last updated on: 2021-05-24
 
 set -e
 SCRIPTS_DIR=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
@@ -25,6 +25,7 @@ Options:
   -t NUM            Number of threads. (default=1)
   -opts OPTIONS     MetaBAT2's options.
   -h, --help        Show this help.
+  -hh               Show MetaBAT2's help message.
 HELP_USAGE
 }
 
@@ -35,6 +36,7 @@ validate_arguments "$#"
 while (("$#")); do
     case "$1" in
         -h|--help ) usage; exit 0 ;;
+        -hh )      activate_env metabiome-metabat2; metabat2 -h; exit 0 ;;
         -i )       input_dir=$(readlink -f "$2"); shift 2 ;;
         -o )       out_dir=$(readlink -m "$2"); shift 2 ;;
         -co )      cov_dir=$(readlink -m "$2"); shift 2 ;;

--- a/scripts/metaphlan3.sh
+++ b/scripts/metaphlan3.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # MetaPhlAn3 wrapper script for the taxonomic profiling of metagenomic reads.
 # Written by: Phagomica Group
-# Last updated on: 2021-02-05
+# Last updated on: 2021-05-24
 
 set -e
 SCRIPTS_DIR=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
@@ -23,6 +23,7 @@ Options:
   -t    NUM         Number of threads to use. (default=1)
   -opts OPTIONS     MetaPhlAn3's options.
   -h, --help        Show this help.
+  -hh               Show MetaPhlAn3's help message.
 HELP_USAGE
 }
 
@@ -33,6 +34,7 @@ validate_arguments "$#"
 while (("$#")); do
     case "$1" in
         -h|--help ) usage; exit 0;;
+        -hh )       activate_env metabiome-taxonomic-profiling; metaphlan -h; exit 0;;
         -i )        input_dir=$(readlink -f "$2"); shift 2;;
         -o )        out_dir=$(readlink -m "$2"); shift 2;;
         -d )        met_db=$(readlink -m "$2"); shift 2;;

--- a/scripts/metaquast.sh
+++ b/scripts/metaquast.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # metaQUAST 5.0 wrapper script
-# Last updated on: 2020-12-13
+# Last updated on: 2021-05-24
 
 set -e
 
@@ -21,6 +21,7 @@ Options:
   -t NUM          Number of threads to use
   -opts OPTIONS   Additional options to use with metaQUAST
   -h, --help      Show this help
+  -hh             Show MetaQUAST's help message.
 HELP_USAGE
 }
 
@@ -31,6 +32,7 @@ validate_arguments "$#"
 while (("$#")); do
     case "$1" in
         -h|--help ) usage; exit 0 ;;
+        -hh )       activate_env metabiome-genome-assembly; metaquast.py -h; exit 0 ;;
         -i )        input_dir=$(readlink -f "$2"); shift 2;;
         -o )        out_dir=$(readlink -m "$2"); shift 2;;
         -t )        threads="$2"; shift 2;;

--- a/scripts/metaspades.sh
+++ b/scripts/metaspades.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Metagenomic assembly using metaSPAdes from SPAdes-3.12.0
 # Written by: Phagomica_club
+# Last updated on: 2021-05-24
 
 set -e
 
@@ -21,6 +22,7 @@ Options:
   -t NUM          Number of threads to use (default: 4).
   -opts OPTIONS   MetaSPADES's options.
   -h, --help      Show this help.
+  -hh             Show metaSPAdes's help message.
 HELP_USAGE
 }
 
@@ -30,6 +32,7 @@ validate_arguments "$#"
 while [[ -n "$1" ]]; do
     case "$1" in
         -h|--help ) usage; exit 0 ;;
+        -hh )       activate_env metabiome-genome-assembly; metaspades.py -h; exit 0 ;;
         -i )        input_dir=$(readlink -f "$2"); shift ;;
         -o )        out_dir=$(readlink -m "$2"); shift ;;
         -t )        threads="$2"; shift ;;

--- a/scripts/trimmomatic.sh
+++ b/scripts/trimmomatic.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Trimmomatic wrapper script to make quality control on FASTQ files
-# Last updated on: 2021-02-08
+# Last updated on: 2021-05-24
 
 set -e
 
@@ -20,6 +20,7 @@ Required:
 Options:
   -t NUM       Number of threads to use (default: 4)
   -h, --help   Show this help
+  -hh          Show Trimmomatic's help message.
 HELP_USAGE
 }
 
@@ -29,6 +30,7 @@ validate_arguments "$#"
 while (("$#")); do
     case "$1" in
         -h|--help ) usage; exit 0 ;;
+        -hh )       activate_env metabiome-preprocessing; trimmomatic -h; exit 0 ;;
         -i )        input_dir=$(readlink -f "$2"); shift 2 ;;
         -o )        out_dir=$(readlink -m "$2"); shift 2 ;;
         -t )        threads="$2"; shift 2 ;;


### PR DESCRIPTION
Hi!

I had the idea of providing and additional flag named `-hh` that allows the users to see the programs native help message, for example running `metabiome metaspades -hh` would show the help message from metaSPAdes. Give it a check out.

Notes:
- It seems that Krona doesn't have a help command.
- FastQC and MultiQC usage in our pipeline is very straightforward, so I saw no need to include the new option for these programs.